### PR TITLE
WebAuthn

### DIFF
--- a/main.js
+++ b/main.js
@@ -121,3 +121,64 @@ app.ports.newGame.subscribe(async ([nonce, gameName]) => {
     invalidateSession(gameName);
   }
 });
+
+app.ports.authRegister.subscribe(async (username) => {
+  console.log("Register as user", username);
+  let resp = await fetch(`http${ssl ? 's' : ''}://${host}/login/register`, {
+    method: 'POST',
+    body: JSON.stringify({username}),
+    headers: {
+      'Content-Type': 'application/json'
+    }
+  });
+  let json = await resp.json();
+
+  let challenge = json.challenge;
+
+  // This should be a challenge, which we should complete
+  let credential = await navigator.credentials.create({
+    publicKey: {
+      challenge: challenge,
+      rp: { name: "Plank Server" },
+      user: { // TODO: Track information about the user id locally?
+        name: username
+      },
+      pubKeyCredParams: [ {type: "public-key", alg: -7} ]
+    }
+  });
+  console.log(credential);
+  
+  // TODO: Complete the registration process
+
+  // sessionStorage.setItem('session', JSON.stringify(json));
+  // app.ports.sessionReceive.send(json);
+});
+
+app.ports.authLogin.subscribe(async (username) => {
+  // TODO: Show error if not supported
+  // let challenge0 = new Uint8Array([139, 66, 181, 87, 7, 203, 181, 87, 7, 203, 181, 87, 7, 203, 181, 87, 7, 203, 181, 87, 7, 203, 181, 87, 7, 203, 181, 87, 7, 203, 181, 87, 7, 203, 181, 87, 7, 203, 181, 87, 7, 203, 181, 87, 7, 203, 203, 181, 87, 7, 203, 203, 181, 87, 7, 203, 203, 181, 87, 7, 203, 203, 181, 87, 7, 203, 203, 181, 87, 7, 203]);
+
+  // let credential0 = await navigator.credentials.create({
+  //   publicKey: {
+  //     challenge: challenge0,
+  //     rp: { id: "localhost", name: "Plank Server" },
+  //     user: {
+  //       id: new Uint8Array([79, 252, 83, 72, 214, 7, 89, 26]),
+  //       name: "jamiedoe",
+  //       displayName: "Jamie Doe"
+  //     },
+  //     pubKeyCredParams: [ {type: "public-key", alg: -7} ]
+  //   }
+  // });
+  // console.log(credential0);
+
+  let challenge1 = new Uint8Array([140, 66, 181, 87, 7, 203, 181, 87, 7, 203, 181, 87, 7, 203, 181, 87, 7, 203, 181, 87, 7, 203, 181, 87, 7, 203, 181, 87, 7, 203, 181, 87, 7, 203, 181, 87, 7, 203, 181, 87, 7, 203, 181, 87, 7, 203, 203, 181, 87, 7, 203, 203, 181, 87, 7, 203, 203, 181, 87, 7, 203, 203, 181, 87, 7, 203, 203, 181, 87, 7, 203]);
+
+  let credential1 = await navigator.credentials.get({
+    publicKey: {
+      challenge: challenge1,
+      rp: { id: "localhost", name: "Plank Server" }
+    }
+  });
+  console.log(credential1);
+});

--- a/plank-server.js
+++ b/plank-server.js
@@ -110,9 +110,14 @@ async function handleRequest(request, env) {
       await env.plank_guests.put(nonce, playerId, {expirationTtl: GUEST_TTL});
       return jsonResp({playerId, nonce});
     } else if (pathnames[0] === 'register') {
-      // TODO: Track this so that we can finish registration
-      let challenge = getRandomNonce();
-      return jsonResp({challenge});
+      if (pathnames[1] === 'start') {
+        // TODO: Track this so that we can finish registration
+        let playerId = generatePlayerId();
+        let challenge = getRandomNonce();
+        return jsonResp({playerId, challenge});
+      } else if (pathnames[1] === 'complete') {
+        // TODO:
+      }
     } else {
       return notFound();
     }

--- a/plank-server.js
+++ b/plank-server.js
@@ -109,6 +109,10 @@ async function handleRequest(request, env) {
       let nonce = getRandomNonce();
       await env.plank_guests.put(nonce, playerId, {expirationTtl: GUEST_TTL});
       return jsonResp({playerId, nonce});
+    } else if (pathnames[0] === 'register') {
+      // TODO: Track this so that we can finish registration
+      let challenge = getRandomNonce();
+      return jsonResp({challenge});
     } else {
       return notFound();
     }

--- a/src/Auth.elm
+++ b/src/Auth.elm
@@ -1,0 +1,7 @@
+port module Auth exposing (..)
+
+
+port authLogin : String -> Cmd msg
+
+
+port authRegister : String -> Cmd msg

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -1,6 +1,7 @@
 module Main exposing (Model, Msg(..), init, main, subscriptions, update, view)
 
 import Action
+import Auth
 import Browser
 import Browser.Navigation as Nav
 import Console exposing (log)
@@ -32,6 +33,9 @@ type Msg
     | UrlChanged Url
     | SetSession (Result Decode.Error Session)
     | ReLogin (Maybe String)
+    | SetLoginUsername String
+    | AuthLogin
+    | AuthRegister
 
 
 main : Program Value Model Msg
@@ -53,6 +57,7 @@ type alias Model =
     , session : Maybe Session
     , key : Nav.Key
     , route : Routes.Route
+    , loginUsername : String
     }
 
 
@@ -84,6 +89,7 @@ init flags url key =
       , session = session
       , key = key
       , route = route
+      , loginUsername = ""
       }
     , case ( session, route ) of
         ( Just { nonce }, Routes.Game gameId ) ->
@@ -125,6 +131,11 @@ viewHome model =
             , div []
                 [ input [ placeholder "game_...", value model.inputGameId, onInput SetInputGameId ] []
                 , button [ onClick (JoinGame model.inputGameId) ] [ text "Join Game" ]
+                ]
+            , div []
+                [ input [ placeholder "Username", value model.loginUsername, onInput SetLoginUsername ] []
+                , button [ onClick AuthRegister ] [ text "Register" ]
+                , button [ onClick AuthLogin ] [ text "Login" ]
                 ]
             ]
         ]
@@ -295,6 +306,15 @@ update msg model =
             -- TODO: Try to connect game again
             -- TODO: Careful, since this can loop for so many reasons
             ( { model | session = Nothing }, Cmd.none )
+
+        SetLoginUsername s ->
+            ( { model | loginUsername = s }, Cmd.none )
+
+        AuthLogin ->
+            ( model, Auth.authLogin model.loginUsername )
+
+        AuthRegister ->
+            ( model, Auth.authRegister model.loginUsername )
 
 
 subscriptions : Model -> Sub Msg


### PR DESCRIPTION
This patch starts to buid a passwordless (WebAuthn) flow for full-fledged accounts. Currently, I just need a better handle on how to validate the result of a WebAuthn request on the server (in the CloudFlare Worker), but otherwise this seems fairly straightforward. Unfortunately, YubiKeys don't have identity associated with them (I dunno!), so you need to track a username, but that's probably okay from a UX perspective. Or we could ditch usernames and say email address + webauthn, which would make it easy to also recover your account if you ever lose access to your key.

The final step here would be to think about the guest versus authenticated flow. Right now we auth you as a guest when you come to the page, but technically if you're about to login that seems wasteful, so we could consider asking you 'do you want to sign in?' but then that becomes a drag if you just want to spectate or whatever. So some thoughts need to be put there, too.

Also note: Passkey and WebAuthn is mostly supported (technically) everywhere, but it's very new as a UX experience. This just seems like a fun playgrond to test it out.